### PR TITLE
Update cloth-config-fabric dependency version for 1.21.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	
 	// Only compile-time dependencies for API access - versions match installed mods
-	modCompileOnly "com.terraformersmc:modmenu:15.0.0-beta.3"
+	modCompileOnly "com.terraformersmc:modmenu:16.0.0-rc.1"
 	modCompileOnly "me.shedaniel.cloth:cloth-config-fabric:20.0.148"
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 	
 	// Only compile-time dependencies for API access - versions match installed mods
 	modCompileOnly "com.terraformersmc:modmenu:15.0.0-beta.3"
-	modCompileOnly "me.shedaniel.cloth:cloth-config-fabric:19.0.147"
+	modCompileOnly "me.shedaniel.cloth:cloth-config-fabric:20.0.148"
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.9
-yarn_mappings=1.21.9+build.1
-loader_version=0.17.2
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
+loader_version=0.17.3
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties
-mod_version=1.3.0
+mod_version=1.3.1
 maven_group=haage
 archives_base_name=locator-heads
 
 # Dependencies
-fabric_version=0.134.0+1.21.9
+fabric_version=0.135.0+1.21.10


### PR DESCRIPTION
Cloth-config was created an error when trying to launch the game with 1.21.10. Bumped Cloth dependancy to latest version.